### PR TITLE
v0.12.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-export VERSION=v0.11.1
+export VERSION=v0.11.2

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run \
   --name   vyos-fw-gui \
   --expose 8080 \
   --mount  source=vyos-fw-gui_data,target=/opt/vyos-fw-gui/data \
-  ibehren1/vyos-fw-gui:v0.11.1
+  ibehren1/vyos-fw-gui:v0.11.2
 ```
 
 ## Docker Compose
@@ -30,7 +30,7 @@ docker run \
 version: '3.7'
 services:
   vyos-fw-gui:
-    image: ibehren1/vyos-fw-gui:v0.11.1
+    image: ibehren1/vyos-fw-gui:v0.11.2
     container_name: vyos-fw-gui
     ports:
       - 8080:8080/tcp

--- a/README.md
+++ b/README.md
@@ -1,227 +1,16 @@
 # vyos-fw-gui
 
-## GUI for creating VyOS firewall rule configuration commands
+## GUI for creating VyOS firewall rule configurations
 
-The webform generates and displays the syntactically correct configuration commands can then be cp/pasted to the CLI for firewall rule configuration.
+The web GUI allows the user to visually create and manage group objects, firewall chains/rules and filter chains/rules for multiple firewalls. Additionally, user can push the created policy to the firewalls via SSH connectivity via the Napalm framework or download the configuation commands to apply via console. Additionally, user can import/export a JSON file of the vyos-fw-gui configuration to move between instances of the GUI.
 
-Source code: [https://github.com/ibehren1/vyos-fw-gui]( https://github.com/ibehren1/vyos-fw-gui)  
-Docker Hub: [https://hub.docker.com/repository/docker/ibehren1/vyos-fw-gui/general](https://hub.docker.com/repository/docker/ibehren1/vyos-fw-gui/general)  
-Working demo:  [https://vyos-fw-gui.com](https://vyos-fw-gui.com)
+| | |
+| - | - |
+| Source code | [https://github.com/ibehren1/vyos-fw-gui](https://github.com/ibehren1/vyos-fw-gui)  |
+| Docker Hub | [https://hub.docker.com/repository/docker/ibehren1/vyos-fw-gui/general](https://hub.docker.com/repository/docker/ibehren1/vyos-fw-gui/general)  |
+| Working demo | [https://vyos-fw-gui.com](https://vyos-fw-gui.com)|
 
-Close to 1.0.0 release.
-
-NEW in version v0.10.2 is the ability to push the configuration to firewalls via SSH.
-
-- Uses napalm python library.
-- More refinements to come - basic functionality available.
-
-## Interface
-
-![image](./images/vyos-fw-gui_interface_1.png)
-![image](./images/vyos-fw-gui_interface_2.png)
-![image](./images/vyos-fw-gui_interface_3.png)
-![image](./images/vyos-fw-gui_interface_4.png)
-![image](./images/vyos-fw-gui_interface_5.png)
-
-## Sample Output
-
-```text
-#
-#
-# IPV4
-#
-#
-
-#
-# Groups
-#
-
-# Group: DNS_Servers
-set firewall group address-group DNS_Servers description 'DNS_Servers'
-set firewall group address-group DNS_Servers address '10.53.53.53'
-
-# Group: DNS_Port
-set firewall group port-group DNS_Port description 'DNS_Port'
-set firewall group port-group DNS_Port port '53'
-
-# Group: SSH_Port
-set firewall group port-group SSH_Port description 'SSH_Port'
-set firewall group port-group SSH_Port port '22'
-
-# Group: Web_Ports
-set firewall group port-group Web_Ports description 'Web_Ports'
-set firewall group port-group Web_Ports port '80'
-set firewall group port-group Web_Ports port '443'
-
-#
-# Filter: input
-#
-set firewall ipv4 input filter descriptionn 'Input Filter'
-set firewall ipv4 input filter default-action 'accept'
-
-
-# Rule 10
-set firewall ipv4 input filter rule 10 description 'WAN LOCAL'
-set firewall ipv4 input filter rule 10 action 'jump'
-set firewall ipv4 input filter rule 10 inbound-interface 'eth0'
-set firewall ipv4 input filter rule 10 jump-target 'WAN_LOCAL'
-
-
-#
-# Filter: forward
-#
-set firewall ipv4 forward filter descriptionn 'Forward Filter'
-set firewall ipv4 forward filter default-action 'accept'
-
-
-# Rule 10
-set firewall ipv4 forward filter rule 10 description 'WAN IN'
-set firewall ipv4 forward filter rule 10 action 'jump'
-set firewall ipv4 forward filter rule 10 inbound-interface 'eth0'
-set firewall ipv4 forward filter rule 10 jump-target 'WAN_IN'
-
-
-#
-# Chain: WAN_LOCAL
-#
-set firewall ipv4 name WAN_LOCAL default-action 'drop'
-set firewall ipv4 name WAN_LOCAL description 'WAN inbound to localhost.'
-
-
-# Rule 10
-set firewall ipv4 name WAN_LOCAL rule 10 description 'Allow established/related.'
-set firewall ipv4 name WAN_LOCAL rule 10 action 'accept'
-set firewall ipv4 name WAN_LOCAL rule 10 state 'established'
-set firewall ipv4 name WAN_LOCAL rule 10 state 'related'
-
-# Rule 20
-set firewall ipv4 name WAN_LOCAL rule 20 description 'Drop invalid.'
-set firewall ipv4 name WAN_LOCAL rule 20 action 'drop'
-set firewall ipv4 name WAN_LOCAL rule 20 log
-set firewall ipv4 name WAN_LOCAL rule 20 state 'invalid'
-
-#
-# Chain: WAN_IN
-#
-set firewall ipv4 name WAN_IN default-action 'drop'
-set firewall ipv4 name WAN_IN description 'WAN inbound to LAN.'
-
-
-# Rule 10
-set firewall ipv4 name WAN_IN rule 10 description 'Allow established/related.'
-set firewall ipv4 name WAN_IN rule 10 action 'accept'
-set firewall ipv4 name WAN_IN rule 10 state 'established'
-set firewall ipv4 name WAN_IN rule 10 state 'related'
-
-# Rule 20
-set firewall ipv4 name WAN_IN rule 20 description 'Drop invalid.'
-set firewall ipv4 name WAN_IN rule 20 action 'drop'
-set firewall ipv4 name WAN_IN rule 20 log
-set firewall ipv4 name WAN_IN rule 20 state 'invalid'
-
-#
-#
-# IPV6
-#
-#
-
-#
-# Groups
-#
-
-# Group: DNS_Servers
-set firewall group ipv6-address-group DNS_Servers description 'DNS_Servers'
-set firewall group ipv6-address-group DNS_Servers address 'fc00::53'
-
-# Group: DNS_Port
-set firewall group ipv6-port-group DNS_Port description 'DNS_Port'
-set firewall group ipv6-port-group DNS_Port port '53'
-
-# Group: SSH_Port
-set firewall group ipv6-port-group SSH_Port description 'SSH_Port'
-set firewall group ipv6-port-group SSH_Port port '22'
-
-# Group: Web_Ports
-set firewall group ipv6-port-group Web_Ports description 'Web_Ports'
-set firewall group ipv6-port-group Web_Ports port '80'
-set firewall group ipv6-port-group Web_Ports port '443'
-
-#
-# Filter: input
-#
-set firewall ipv6 input filter descriptionn 'Input Filter'
-set firewall ipv6 input filter default-action 'accept'
-
-
-# Rule 10
-set firewall ipv6 input filter rule 10 description 'WAN LOCAL'
-set firewall ipv6 input filter rule 10 action 'jump'
-set firewall ipv6 input filter rule 10 inbound-interface 'eth0'
-set firewall ipv6 input filter rule 10 jump-target 'WAN_LOCAL'
-
-
-#
-# Filter: forward
-#
-set firewall ipv6 forward filter descriptionn 'Forward Filter'
-set firewall ipv6 forward filter default-action 'accept'
-
-
-# Rule 10
-set firewall ipv6 forward filter rule 10 description 'WAN IN'
-set firewall ipv6 forward filter rule 10 action 'jump'
-set firewall ipv6 forward filter rule 10 inbound-interface 'eth0'
-set firewall ipv6 forward filter rule 10 jump-target 'WAN_IN'
-
-
-#
-# Chain: WAN_LOCAL
-#
-set firewall ipv6 name WAN_LOCAL default-action 'drop'
-set firewall ipv6 name WAN_LOCAL description 'WAN inbound to localhost.'
-
-
-# Rule 10
-set firewall ipv6 name WAN_LOCAL rule 10 description 'Allow established/related.'
-set firewall ipv6 name WAN_LOCAL rule 10 action 'accept'
-set firewall ipv6 name WAN_LOCAL rule 10 state 'established'
-set firewall ipv6 name WAN_LOCAL rule 10 state 'related'
-
-# Rule 20
-set firewall ipv6 name WAN_LOCAL rule 20 description 'Drop invalid.'
-set firewall ipv6 name WAN_LOCAL rule 20 action 'drop'
-set firewall ipv6 name WAN_LOCAL rule 20 log
-set firewall ipv6 name WAN_LOCAL rule 20 state 'invalid'
-
-# Rule 30
-set firewall ipv6 name WAN_LOCAL rule 30 description 'Allow ICMP.'
-set firewall ipv6 name WAN_LOCAL rule 30 action 'accept'
-set firewall ipv6 name WAN_LOCAL rule 30 protocol 'ipv6-icmp'
-
-#
-# Chain: WAN_IN
-#
-set firewall ipv6 name WAN_IN default-action 'drop'
-set firewall ipv6 name WAN_IN description 'WAN inbound to LAN.'
-
-
-# Rule 10
-set firewall ipv6 name WAN_IN rule 10 description 'Allow established/related.'
-set firewall ipv6 name WAN_IN rule 10 action 'accept'
-set firewall ipv6 name WAN_IN rule 10 state 'established'
-set firewall ipv6 name WAN_IN rule 10 state 'related'
-
-# Rule 20
-set firewall ipv6 name WAN_IN rule 20 description 'Drop invalid.'
-set firewall ipv6 name WAN_IN rule 20 action 'drop'
-set firewall ipv6 name WAN_IN rule 20 log
-set firewall ipv6 name WAN_IN rule 20 state 'invalid'
-
-# Rule 30
-set firewall ipv6 name WAN_IN rule 30 description 'Allow ICMP.'
-set firewall ipv6 name WAN_IN rule 30 action 'accept'
-set firewall ipv6 name WAN_IN rule 30 protocol 'ipv6-icmp'
-```
+Recommended deployment is via Docker but also inculded in the repo is a systemd service file for use with local install.
 
 ## Docker Run
 
@@ -251,3 +40,11 @@ services:
 volumes:
   data:
 ```
+
+## Interface
+
+![image](./images/vyos-fw-gui_interface_1.png)
+![image](./images/vyos-fw-gui_interface_2.png)
+![image](./images/vyos-fw-gui_interface_3.png)
+![image](./images/vyos-fw-gui_interface_4.png)
+![image](./images/vyos-fw-gui_interface_5.png)

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,8 @@
 - [x] Display chains visually.
 - [x] Display filters visually.
   - [ ] Make visual display of filters prettier.
+- [ ] Add section of commands for options not yet implemented.
+- [x] Show groups in sections by group type.
 
 ## Design
 

--- a/app.py
+++ b/app.py
@@ -418,6 +418,13 @@ def configuration_push():
         if "ssh_key_name" in request.form:
             connection_string["ssh_key_name"] = request.form["ssh_key_name"]
 
+        # Include 'delete firewall' before set commands
+        message, config = generate_config(session)
+        if "delete_before_set" in request.form:
+            write_user_command_conf_file(session, config, delete=True)
+        else:
+            write_user_command_conf_file(session, config, delete=False)
+
         if request.form["action"] == "View Diffs":
             message = get_diffs_from_firewall(connection_string, session)
         if request.form["action"] == "Commit":
@@ -445,7 +452,6 @@ def configuration_push():
         file_list = list_user_files(session)
         key_list = list_user_keys(session)
         message, config = generate_config(session)
-        write_user_command_conf_file(session, config)
         firewall_reachable = test_connection(session)
 
         return render_template(

--- a/app.py
+++ b/app.py
@@ -25,7 +25,9 @@ from package.chain_functions import (
 )
 from package.database_functions import process_login, query_user_by_id, register_user
 from package.data_file_functions import (
+    add_extra_items,
     add_hostname,
+    get_extra_items,
     get_system_name,
     initialize_data_dir,
     list_user_files,
@@ -383,6 +385,29 @@ def filter_view():
 
 #
 # Configuration
+@app.route("/configuration_extra_items", methods=["Get", "POST"])
+@login_required
+def configuration_extra_items():
+    if request.method == "POST":
+        print(request.form["extra_items"])
+
+        add_extra_items(session, request)
+
+        return redirect(url_for("display_config"))
+
+    else:
+        file_list = list_user_files(session)
+        extra_items = get_extra_items(session)
+
+        return render_template(
+            "configuration_extra_items.html",
+            extra_items=extra_items,
+            file_list=file_list,
+            firewall_name=session["firewall_name"],
+            username=session["username"],
+        )
+
+
 @app.route("/configuration_hostname_add", methods=["GET", "POST"])
 @login_required
 def configuration_hostname_add():
@@ -467,6 +492,23 @@ def configuration_push():
         )
 
 
+@app.route("/create_config", methods=["POST"])
+@login_required
+def create_config():
+    if request.form["config_name"] == "":
+        flash("Config name cannot be empty", "danger")
+        return redirect(url_for("index"))
+    else:
+        user_data = {}
+
+        session["firewall_name"] = request.form["config_name"]
+        write_user_data_file(
+            f'{session["data_dir"]}/{request.form["config_name"]}', user_data
+        )
+
+    return redirect(url_for("display_config"))
+
+
 @app.route("/display_config")
 @login_required
 def display_config():
@@ -492,23 +534,6 @@ def display_config():
             message=message,
             username=session["username"],
         )
-
-
-@app.route("/create_config", methods=["POST"])
-@login_required
-def create_config():
-    if request.form["config_name"] == "":
-        flash("Config name cannot be empty", "danger")
-        return redirect(url_for("index"))
-    else:
-        user_data = {}
-
-        session["firewall_name"] = request.form["config_name"]
-        write_user_data_file(
-            f'{session["data_dir"]}/{request.form["config_name"]}', user_data
-        )
-
-    return redirect(url_for("display_config"))
 
 
 @app.route("/delete_config", methods=["POST"])

--- a/app.py
+++ b/app.py
@@ -294,7 +294,7 @@ def filter_add():
     if request.method == "POST":
         add_filter_to_data(session, request)
 
-        return redirect(url_for("display_config"))
+        return redirect(url_for("filter_view"))
 
     else:
         file_list = list_user_files(session)
@@ -313,7 +313,7 @@ def filter_rule_add():
     if request.method == "POST":
         add_filter_rule_to_data(session, request)
 
-        return redirect(url_for("display_config"))
+        return redirect(url_for("filter_view"))
 
     else:
         file_list = list_user_files(session)
@@ -344,7 +344,7 @@ def filter_rule_delete():
     if request.method == "POST":
         delete_filter_rule_from_data(session, request)
 
-        return redirect(url_for("display_config"))
+        return redirect(url_for("filter_view"))
 
     else:
         file_list = list_user_files(session)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   vyos-fw-gui:
-    image: ibehren1/vyos-fw-gui:v0.11.1
+    image: ibehren1/vyos-fw-gui:v0.11.2
     container_name: vyos-fw-gui
     ports:
       - 8080:8080/tcp

--- a/package/chain_functions.py
+++ b/package/chain_functions.py
@@ -47,18 +47,10 @@ def add_rule_to_data(session, request):
             return
     if request.form["dest_address_type"] == "domain_group":
         rule_dict["dest_address_type"] = "domain_group"
-        if request.form["dest_domain_group"].split(",")[0] == ip_version:
-            rule_dict["dest_address"] = request.form["dest_domain_group"].split(",")[1]
-        else:
-            flash_ip_version_mismatch()
-            return
+        rule_dict["dest_address"] = request.form["dest_domain_group"].split(",")[1]
     if request.form["dest_address_type"] == "mac_group":
         rule_dict["dest_address_type"] = "mac_group"
-        if request.form["dest_mac_group"].split(",")[0] == ip_version:
-            rule_dict["dest_address"] = request.form["dest_mac_group"].split(",")[1]
-        else:
-            flash_ip_version_mismatch()
-            return
+        rule_dict["dest_address"] = request.form["dest_mac_group"].split(",")[1]
     if request.form["dest_address_type"] == "network_group":
         rule_dict["dest_address_type"] = "network_group"
         if request.form["dest_network_group"].split(",")[0] == ip_version:
@@ -71,11 +63,7 @@ def add_rule_to_data(session, request):
         rule_dict["dest_port"] = request.form["dest_port"].strip()
     if request.form["dest_port_type"] == "port_group":
         rule_dict["dest_port_type"] = "port_group"
-        if request.form["dest_port_group"].split(",")[0] == ip_version:
-            rule_dict["dest_port"] = request.form["dest_port_group"].split(",")[1]
-        else:
-            flash_ip_version_mismatch()
-            return
+        rule_dict["dest_port"] = request.form["dest_port_group"].split(",")[1]
 
     # Process source
     if request.form["source_address_type"] == "address":
@@ -92,20 +80,10 @@ def add_rule_to_data(session, request):
             return
     if request.form["source_address_type"] == "domain_group":
         rule_dict["source_address_type"] = "domain_group"
-        if request.form["source_domain_group"].split(",")[0] == ip_version:
-            rule_dict["source_address"] = request.form["source_domain_group"].split(
-                ","
-            )[1]
-        else:
-            flash_ip_version_mismatch()
-            return
+        rule_dict["source_address"] = request.form["source_domain_group"].split(",")[1]
     if request.form["source_address_type"] == "mac_group":
         rule_dict["source_address_type"] = "mac_group"
-        if request.form["source_mac_group"].split(",")[0] == ip_version:
-            rule_dict["source_address"] = request.form["source_mac_group"].split(",")[1]
-        else:
-            flash_ip_version_mismatch()
-            return
+        rule_dict["source_address"] = request.form["source_mac_group"].split(",")[1]
     if request.form["source_address_type"] == "network_group":
         rule_dict["source_address_type"] = "network_group"
         if request.form["source_network_group"].split(",")[0] == ip_version:
@@ -120,11 +98,7 @@ def add_rule_to_data(session, request):
         rule_dict["source_port"] = request.form["source_port"].strip()
     if request.form["source_port_type"] == "port_group":
         rule_dict["source_port_type"] = "port_group"
-        if request.form["source_port_group"].split(",")[0] == ip_version:
-            rule_dict["source_port"] = request.form["source_port_group"].split(",")[1]
-        else:
-            flash_ip_version_mismatch()
-            return
+        rule_dict["source_port"] = request.form["source_port_group"].split(",")[1]
 
     rule_dict["protocol"] = (
         request.form["protocol"] if "protocol" in request.form else ""

--- a/package/chain_functions.py
+++ b/package/chain_functions.py
@@ -167,6 +167,10 @@ def add_chain_to_data(session, request):
     fw_chain = request.form["fw_chain"]
     description = request.form["description"]
     default_action = request.form["default_action"]
+    if "logging" in request.form:
+        default_logging = True
+    else:
+        default_logging = False
 
     # Check and create higher level data structure if it does not exist
     if ip_version not in user_data:
@@ -179,6 +183,9 @@ def add_chain_to_data(session, request):
     if "default" not in user_data[ip_version]["chains"][fw_chain]:
         user_data[ip_version]["chains"][fw_chain]["default"] = {}
     user_data[ip_version]["chains"][fw_chain]["default"]["description"] = description
+    user_data[ip_version]["chains"][fw_chain]["default"][
+        "default_logging"
+    ] = default_logging
     user_data[ip_version]["chains"][fw_chain]["default"][
         "default_action"
     ] = default_action

--- a/package/data_file_functions.py
+++ b/package/data_file_functions.py
@@ -11,6 +11,39 @@ import string
 
 
 #
+# Add extra items
+def add_extra_items(session, request):
+    # Get user's data
+    user_data = read_user_data_file(f'{session["data_dir"]}/{session["firewall_name"]}')
+    default_extra_items = [
+        "# Enter set commands here, one per line.",
+        "# set firewall global-options all-ping 'enable'",
+        "# set firewall global-options log-martians 'disable'",
+    ]
+
+    extra_items = []
+
+    for item in request.form["extra_items"].split("\r"):
+        item = item.strip("\n")
+        if item != "":
+            extra_items.append(item)
+
+    print(extra_items)
+
+    if extra_items == default_extra_items:
+        print("MATCH")
+        flash(f"There are no extra configuration items to add.", "warning")
+        return
+    else:
+        user_data["extra-items"] = extra_items
+        write_user_data_file(
+            f'{session["data_dir"]}/{session["firewall_name"]}', user_data
+        )
+        flash(f"Extra items added to configuration.", "success")
+        return
+
+
+#
 # Add hostname
 def add_hostname(session, reqest):
     # Get user's data
@@ -60,6 +93,30 @@ def decrypt_file(filename, key):
     #     flash("Authentication error.", "danger")
     #     print(" |")
     #     return "Auth Error"
+
+
+#
+# Get extra items
+def get_extra_items(session):
+    # Get user's data
+    user_data = read_user_data_file(f'{session["data_dir"]}/{session["firewall_name"]}')
+
+    # Create list of defined filters
+    extra_items = []
+    if "extra-items" in user_data:
+        for item in user_data["extra-items"]:
+            extra_items.append(item)
+
+    # If there are no filters, flash message
+    if extra_items == []:
+        flash(f"There are no extra configuration items defined.", "warning")
+        extra_items = [
+            "# Enter set commands here, one per line.",
+            "# set firewall global-options all-ping 'enable'",
+            "# set firewall global-options log-martians 'disable'",
+        ]
+
+    return extra_items
 
 
 #

--- a/package/data_file_functions.py
+++ b/package/data_file_functions.py
@@ -272,10 +272,18 @@ def update_schema(user_data):
 
 #
 # Write User commands.conf file
-def write_user_command_conf_file(session, command_list):
+def write_user_command_conf_file(session, command_list, delete=False):
+    print(f"Delete_before_set: {delete}")
     with open(f'{session["data_dir"]}/{session["firewall_name"]}.conf', "w") as f:
-        for line in command_list:
-            f.write(f"{line}\n")
+        if delete == True:
+            f.write(
+                f"#\n# Delete all firewall before setting new values\ndelete firewall\n"
+            )
+            for line in command_list:
+                f.write(f"{line}\n")
+        if delete == False:
+            for line in command_list:
+                f.write(f"{line}\n")
     return
 
 

--- a/package/data_file_functions.py
+++ b/package/data_file_functions.py
@@ -291,5 +291,5 @@ def write_user_command_conf_file(session, command_list, delete=False):
 # Write User Data File
 def write_user_data_file(filename, data):
     with open(f"{filename}.json", "w") as f:
-        f.write(json.dumps(data, indent=4))
+        f.write(json.dumps(data, indent=4, sort_keys=True))
     return

--- a/package/filter_functions.py
+++ b/package/filter_functions.py
@@ -1,6 +1,7 @@
 """
     Filter Support Functions
 """
+
 from package.data_file_functions import read_user_data_file, write_user_data_file
 from flask import flash
 
@@ -128,16 +129,17 @@ def assemble_list_of_filters(session):
 
     # Create list of defined filters
     filter_list = []
-    try:
-        for ip_version in ["ipv4", "ipv6"]:
+    for ip_version in ["ipv4", "ipv6"]:
+        try:
             if ip_version in user_data:
                 for type in user_data[ip_version]["filters"]:
                     filter_list.append([ip_version, type])
-    except:
-        pass
+        except:
+            pass
 
     # If there are no filters, flash message
     if filter_list == []:
+        print("is this it?")
         flash(f"There are no filters defined.", "danger")
 
     return filter_list

--- a/package/filter_functions.py
+++ b/package/filter_functions.py
@@ -13,11 +13,11 @@ def add_filter_rule_to_data(session, request):
     # Set local vars from posted form data
     rule = request.form["rule"]
     rule_dict = {}
-    filter = request.form["filter"].split(",")
-    ip_version = filter[0]
-    rule_dict["ip_version"] = filter[0]
-    rule_dict["filter"] = filter[1]
-    filter = filter[1]
+    filter_info = request.form["filter"].split(",")
+    ip_version = filter_info[0]
+    filter = filter_info[1]
+    rule_dict["ip_version"] = ip_version
+    rule_dict["filter"] = filter
     jump_target = request.form["jump_target"].split(",")
     rule_dict["fw_chain"] = jump_target[1]
     rule_dict["description"] = request.form["description"]
@@ -30,7 +30,8 @@ def add_filter_rule_to_data(session, request):
     rule_dict["direction"] = request.form["direction"]
 
     # Check and create higher level data structure if it does not exist
-    user_data[ip_version]["filters"][filter]["rules"] = {}
+    if "rules" not in user_data[ip_version]["filters"][filter]:
+        user_data[ip_version]["filters"][filter]["rules"] = {}
 
     # Add rule to data structure
     user_data[ip_version]["filters"][filter]["rules"][rule] = rule_dict
@@ -97,8 +98,8 @@ def assemble_detail_list_of_filters(session):
 
     # Create list of defined filters
     filter_dict = {}
-    try:
-        for ip_version in ["ipv4", "ipv6"]:
+    for ip_version in ["ipv4", "ipv6"]:
+        try:
             if ip_version in user_data:
                 filter_dict[ip_version] = {}
                 if "filters" in user_data[ip_version]:
@@ -112,9 +113,9 @@ def assemble_detail_list_of_filters(session):
                             ][rule]
                             rule_detail["number"] = rule
                             filter_dict[ip_version][filter_name].append(rule_detail)
-    except:
-        print("Error in assemble_detail_list_of_rules")
-        pass
+        except:
+            print("Error in assemble_detail_list_of_rules")
+            pass
 
     # If there are no filters, flash message
     if filter_dict == {}:
@@ -139,7 +140,6 @@ def assemble_list_of_filters(session):
 
     # If there are no filters, flash message
     if filter_list == []:
-        print("is this it?")
         flash(f"There are no filters defined.", "danger")
 
     return filter_list

--- a/package/generate_config.py
+++ b/package/generate_config.py
@@ -194,15 +194,22 @@ def generate_config(session):
                         description = user_data[ip_version]["chains"][fw_chain][
                             "default"
                         ]["description"]
+                        default_logging = user_data[ip_version]["chains"][fw_chain][
+                            "default"
+                        ]["default_logging"]
                         default_action = user_data[ip_version]["chains"][fw_chain][
                             "default"
                         ]["default_action"]
                         config.append(
-                            f"set firewall {ip_version} name {fw_chain} default-action '{default_action}'"
-                        )
-                        config.append(
                             f"set firewall {ip_version} name {fw_chain} description '{description}'"
                         )
+                        config.append(
+                            f"set firewall {ip_version} name {fw_chain} default-action '{default_action}'"
+                        )
+                        if default_logging:
+                            config.append(
+                                f"set firewall {ip_version} name {fw_chain} default-log"
+                            )
                         config.append("\n")
 
                     for rule in user_data[ip_version]["chains"][fw_chain]["rule-order"]:

--- a/package/generate_config.py
+++ b/package/generate_config.py
@@ -20,14 +20,29 @@ def generate_config(session):
     # Create firewall configuration
     config = []
 
-    if "ipv4" not in user_data and "ipv6" not in user_data:
+    if (
+        "ipv4" not in user_data
+        and "ipv6" not in user_data
+        and "extra-items" not in user_data
+    ):
         config.append(
             "Empty rule set.  Start by adding a Chain using the button on the right."
         )
 
+    # Add Extra Items
+    if "extra-items" in user_data:
+        config.append(f"#\n#\n# Extra Configuration Items\n#\n#")
+        for item in user_data["extra-items"]:
+            config.append(f"{item}")
+        config.append("")
+
     # Work through each IP Version, Chain and Rule adding to config
     for ip_version in user_data:
-        if ip_version != "version" and ip_version != "system":
+        if (
+            ip_version != "extra-items"
+            and ip_version != "system"
+            and ip_version != "version"
+        ):
             config.append(f"#\n#\n# {ip_version.upper()}\n#\n#\n")
 
             if "groups" in user_data[ip_version]:

--- a/package/generate_config.py
+++ b/package/generate_config.py
@@ -194,9 +194,15 @@ def generate_config(session):
                         description = user_data[ip_version]["chains"][fw_chain][
                             "default"
                         ]["description"]
-                        default_logging = user_data[ip_version]["chains"][fw_chain][
-                            "default"
-                        ]["default_logging"]
+                        if (
+                            "default_logging"
+                            in user_data[ip_version]["chains"][fw_chain]["default"]
+                        ):
+                            default_logging = user_data[ip_version]["chains"][fw_chain][
+                                "default"
+                            ]["default_logging"]
+                        else:
+                            default_logging = False
                         default_action = user_data[ip_version]["chains"][fw_chain][
                             "default"
                         ]["default_action"]

--- a/package/group_funtions.py
+++ b/package/group_funtions.py
@@ -1,6 +1,7 @@
 """
     Group Support functions.
 """
+
 from package.data_file_functions import read_user_data_file, write_user_data_file
 from flask import flash
 
@@ -10,7 +11,11 @@ def add_group_to_data(session, request):
     user_data = read_user_data_file(f'{session["data_dir"]}/{session["firewall_name"]}')
 
     # Set local vars from posted form data
-    ip_version = request.form["ip_version"]
+    group_type = request.form["group_type"]
+    if group_type == "address-group" or group_type == "network-group":
+        ip_version = request.form["ip_version"]
+    else:
+        ip_version = "ipv4"
     group_desc = request.form["group_desc"]
     group_name = request.form["group_name"].replace(" ", "")
     group_type = request.form["group_type"]

--- a/package/napalm_functions.py
+++ b/package/napalm_functions.py
@@ -119,7 +119,10 @@ def commit_to_firewall(connection_string, session):
             print(" |--> Connection closed.\n |")
             vyos_router.close()
 
-            return commit
+            if commit == None:
+                return str(diffs + "Commit successful.")
+            else:
+                return str(diffs + commit)
 
         else:
             print(" |--> No configuration changes to commit")

--- a/package/napalm_functions.py
+++ b/package/napalm_functions.py
@@ -72,12 +72,8 @@ def get_diffs_from_firewall(connection_string, session):
         print(" |--> Connection closed.\n |")
 
         if bool(diffs) == True:
-            print(diffs)
-
             return diffs
-
         else:
-
             return "No configuration changes to commit."
 
     except Exception as e:
@@ -112,7 +108,6 @@ def commit_to_firewall(connection_string, session):
         diffs = vyos_router.compare_config()
 
         if bool(diffs) == True:
-            print(diffs)
             print(" |--> Committing configuration")
             commit = vyos_router.commit_config()
 

--- a/templates/basic_page.html
+++ b/templates/basic_page.html
@@ -269,6 +269,21 @@
                     </tr>
                     <tr>
                         <td align="center" colspan="2">
+                            <br> <br>
+                            <p class="section_heading">
+                                Extra Configurations
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center" colspan="2">
+                            <a href="{{ url_for('configuration_extra_items')}}">
+                                <input class="button" type="submit" value="Add Extra Configurations" style="width: 75%">
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center" colspan="2">
                             <br><br>
                             <hr width="75%">
                             <p class="section_heading">

--- a/templates/basic_page.html
+++ b/templates/basic_page.html
@@ -319,7 +319,7 @@
                 </p>
             </td>
             <td width="50%" align="center" style="vertical-align: middle;">
-                <p class="h4_dark">vyos-fw-gui v0.11.1</p>
+                <p class="h4_dark">vyos-fw-gui v0.11.2</p>
                 <p class="h3_dark">Copyright 2024 Isaac Behrens</p>
             </td>
             <td width="25%" align="center" style="vertical-align: middle;">

--- a/templates/chain_add_form.html
+++ b/templates/chain_add_form.html
@@ -9,7 +9,7 @@
             </th>
         </tr>
         <tr>
-            <td colspan="3">
+            <td colspan="4">
                 For firewall filtering, firewall rules needs to be created. Each rule is numbered, has an action to
                 apply if the rule is matched, and the ability to specify multiple criteria matchers. Data packets go
                 through the rules from 1 - 999999, so order is crucial. At the first match the action of the rule will
@@ -21,14 +21,14 @@
             </td>
         </tr>
         <tr>
-            <td style="vertical-align: top;">
+            <td style="vertical-align: top;" width="20%">
                 <p class="section_heading">
                     IP Version
                 </p>
                 <input type="radio" name="ip_version" value="ipv4" checked="checked">&nbsp;IPv4<br>
                 <input type="radio" name="ip_version" value="ipv6">&nbsp;IPv6<br><br>
             </td>
-            <td style="vertical-align: top;">
+            <td style="vertical-align: top;" width="40%">
                 <p class="section_heading">
                     Firewall Chain
                 </p>
@@ -51,9 +51,16 @@
                     </tr>
                 </table>
             </td>
-            <td style="vertical-align: top;">
+            <td width="20%">
                 <p class="section_heading">
-                    Default Rule Action
+                    Logging
+                </p>
+                <input type="checkbox" id="logging" name="logging" value="True">
+                <label for="logging">&nbsp;Enable</label>
+            </td>
+            <td style="vertical-align: top;" width="20%">
+                <p class="section_heading">
+                    Default Action
                 </p>
                 <input type="radio" name="default_action" value="accept">&nbsp;accept<br>
                 <input type="radio" name="default_action" value="continue">&nbsp;continue<br>
@@ -64,7 +71,7 @@
             </td>
         </tr>
         <tr>
-            <td align="right" colspan="3">
+            <td align="right" colspan="4">
                 <input type="submit" value="Add Chain">
             </td>
         </tr>

--- a/templates/chain_add_form.html
+++ b/templates/chain_add_form.html
@@ -55,7 +55,7 @@
                 <p class="section_heading">
                     Logging
                 </p>
-                <input type="checkbox" id="logging" name="logging" value="True">
+                <input type="checkbox" id="logging" name="logging" value="True" checked>
                 <label for="logging">&nbsp;Enable</label>
             </td>
             <td style="vertical-align: top;" width="20%">

--- a/templates/chain_rule_add_form.html
+++ b/templates/chain_rule_add_form.html
@@ -101,7 +101,6 @@
                                     {% for group in group_list %}
                                     {% if group["group_type"] == "domain-group"%}
                                 <option value='{{group["ip_version"]}},{{group["group_name"]}}'>
-                                    {{group["ip_version"]}}:
                                     {{group["group_name"]}}:
                                     {{group["group_value"]}}
                                 </option>
@@ -114,7 +113,6 @@
                                     {% for group in group_list %}
                                     {% if group["group_type"] == "mac-group"%}
                                 <option value='{{group["ip_version"]}},{{group["group_name"]}}'>
-                                    {{group["ip_version"]}}:
                                     {{group["group_name"]}}:
                                     {{group["group_value"]}}
                                 </option>
@@ -148,7 +146,6 @@
                                     {% for group in group_list %}
                                     {% if group["group_type"] == "port-group"%}
                                 <option value='{{group["ip_version"]}},{{group["group_name"]}}'>
-                                    {{group["ip_version"]}}:
                                     {{group["group_name"]}}:
                                     {{group["group_value"]}}
                                 </option>
@@ -223,7 +220,6 @@
                                     {% for group in group_list %}
                                     {% if group["group_type"] == "domain-group"%}
                                 <option value='{{group["ip_version"]}},{{group["group_name"]}}'>
-                                    {{group["ip_version"]}}:
                                     {{group["group_name"]}}:
                                     {{group["group_value"]}}
                                 </option>
@@ -236,7 +232,6 @@
                                     {% for group in group_list %}
                                     {% if group["group_type"] == "mac-group"%}
                                 <option value='{{group["ip_version"]}},{{group["group_name"]}}'>
-                                    {{group["ip_version"]}}:
                                     {{group["group_name"]}}:
                                     {{group["group_value"]}}
                                 </option>
@@ -270,7 +265,6 @@
                                     {% for group in group_list %}
                                     {% if group["group_type"] == "port-group"%}
                                 <option value='{{group["ip_version"]}},{{group["group_name"]}}'>
-                                    {{group["ip_version"]}}:
                                     {{group["group_name"]}}:
                                     {{group["group_value"]}}
                                 </option>

--- a/templates/configuration_extra_items.html
+++ b/templates/configuration_extra_items.html
@@ -1,0 +1,42 @@
+{% extends "basic_page.html" %}
+{% block body %}
+<br><br>
+<form action="/configuration_extra_items" , method="post">
+    <table class="table">
+        <tr>
+            <td align="center">
+                <h2 class="page_heading">Extra Configuration Items</h2>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                You can add extra configuration statements to configure items that have not yet been implemented in the
+                GUI.
+                This section is only intended to be used for configurations that fall under firewall.<br>
+                <br>
+                Configuration items must be syntactically correct CLI set statements.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label for="freeform">Extra Configuration Items:</label>
+            </td>
+        </tr>
+        <tr>
+            <td align="center">
+                <textarea id="extra_items" name="extra_items" rows="20" cols="80">
+{% for item in extra_items %}
+{%- if item -%}{{-item-}}{% endif %}
+{% endfor%}
+</textarea>
+            </td>
+        </tr>
+        <tr>
+            <td align="right">
+                <input type="submit" value="Add Configuration Items">
+            </td>
+        </tr>
+    </table>
+</form>
+<br><br>
+{% endblock body %}

--- a/templates/configuration_push.html
+++ b/templates/configuration_push.html
@@ -122,8 +122,6 @@
             </td>
             <div class="popup" id="loading" style="display:none;">
                 <img src="static/loading.gif" width="100" height="100">
-                <br>
-                Loading
             </div>
         </tr>
     </form>

--- a/templates/configuration_push.html
+++ b/templates/configuration_push.html
@@ -110,6 +110,20 @@
                             When selecting an SSH key, the password is the encryption key for the SSH key.
                         </td>
                     </tr>
+                    <tr>
+                        <td colspan="3">
+                            <input type="checkbox" id="delete_before_set" name="delete_before_set" value="True">
+                            <label for="delete_before_set">&nbsp;Add 'delete firewall' before set in
+                                configuration.</label><br>
+                            <font style="font-size: 12; background-color: rgb(200, 16, 16); font-weight: bold;">Using
+                                this option
+                                will delete
+                                all firewall
+                                configurations not
+                                contained in this managed configuration.
+                            </font>
+                        </td>
+                    </tr>
                 </table>
             </td>
         </tr>

--- a/templates/filter_rule_add_form.html
+++ b/templates/filter_rule_add_form.html
@@ -76,6 +76,7 @@
                 </p>
                 <label for="jump_target">Jump Target&nbsp;</label>
                 <select name="jump_target" id="jump_target">
+                    <option value=""></option>
                     {% for chain in chain_list %}
                     <option value='{{chain[0]}},{{chain[1]}}'>
                         {{chain[0]}}: {{chain[1]}}

--- a/templates/filter_rule_add_form.html
+++ b/templates/filter_rule_add_form.html
@@ -94,7 +94,8 @@
                             <label for="rule">Interface&nbsp;</label>
                         </td>
                         <td>
-                            <input type="text" id="interface" name="interface" maxlength="10" size="6" value="ethX"><br>
+                            <input type="text" id="interface" name="interface" maxlength="10" size="10"
+                                value="ethX"><br>
                         </td>
                     <tr>
                         <td>

--- a/templates/filter_view.html
+++ b/templates/filter_view.html
@@ -9,19 +9,19 @@
 
 <p class="filter_heading">Filter: {{key}}</p>
 <table class="groups_table" border="1" width="100%" style="font-size: 12;">
-    <th colspan="2">
+    <th>
         Rule
     </th>
 
-    <th colspan="2">
+    <th>
         Description
     </th>
 
-    <th colspan="2">
+    <th>
         Target Chain
     </th>
 
-    <th colspan="1">
+    <th>
         Interface
     </th>
 
@@ -30,20 +30,20 @@
     </th>
 
     {% for rule in filter_list %}
-    <tr align="center" colspan="2" style="vertical-align: middle;">
-        <td align="center" colspan="2" rowspan="2" style="vertical-align: middle;">
+    <tr align="center" style="vertical-align: middle;">
+        <td align="center" style="vertical-align: middle;">
             <font style="font-size:60;">{{rule.number}}</font>
             <br>
             <font style="font-size:30; font-variant: small-caps ;">{{rule.action}}</font>
         </td>
 
-        <td colspan="2" style="vertical-align: middle;">
+        <td style="vertical-align: middle;">
             <font style="font-size:16;">
                 {{rule.description}}
             </font>
         </td>
 
-        <td colspan="2" style="vertical-align: middle;">
+        <td style="vertical-align: middle;">
             <font style="font-size:16;">
                 {{rule.fw_chain}}
             </font>
@@ -76,19 +76,19 @@
 
 <p class="filter_heading">Filter: {{key}}</p>
 <table class="groups_table" border="1" width="100%" style="font-size: 12;">
-    <th colspan="2">
+    <th>
         Rule
     </th>
 
-    <th colspan="2">
+    <th>
         Description
     </th>
 
-    <th colspan="2">
+    <th>
         Target Chain
     </th>
 
-    <th colspan="1">
+    <th>
         Interface
     </th>
 
@@ -97,20 +97,20 @@
     </th>
 
     {% for rule in filter_list %}
-    <tr align="center" colspan="2" style="vertical-align: middle;">
-        <td align="center" colspan="2" rowspan="2" style="vertical-align: middle;">
+    <tr align="center" style="vertical-align: middle;">
+        <td align="center" style="vertical-align: middle;">
             <font style="font-size:60;">{{rule.number}}</font>
             <br>
             <font style="font-size:30; font-variant: small-caps ;">{{rule.action}}</font>
         </td>
 
-        <td colspan="2" style="vertical-align: middle;">
+        <td style="vertical-align: middle;">
             <font style="font-size:16;">
                 {{rule.description}}
             </font>
         </td>
 
-        <td colspan="2" style="vertical-align: middle;">
+        <td style="vertical-align: middle;">
             <font style="font-size:16;">
                 {{rule.fw_chain}}
             </font>
@@ -129,6 +129,7 @@
         </td>
     </tr>
     {% endfor %}
+
 </table>
 {% endfor %}
 {% endif %}

--- a/templates/group_add_form.html
+++ b/templates/group_add_form.html
@@ -25,6 +25,7 @@
 
                 <input type="radio" name="ip_version" value="ipv4" checked="checked">&nbsp;IPv4<br>
                 <input type="radio" name="ip_version" value="ipv6">&nbsp;IPv6<br><br>
+                <font style="font-size: small;">Only applies to address<br>and network groups.</font>
 
             </td>
             <td style="vertical-align: top;">

--- a/templates/group_view.html
+++ b/templates/group_view.html
@@ -17,6 +17,7 @@
     </th>
     {% for item in group_list|sort(attribute='group_name') %}
     {% if item.ip_version == 'ipv4' %}
+    {% if item.group_type == 'address-group' %}
     <tr>
         <td>
             {{item.group_name}}
@@ -24,18 +25,60 @@
         <td>
             {{item.group_desc}}
         </td>
-        <td>
+        <td align="center">
             {{item.group_type}}
         </td>
-        <td>
+        <td align="center">
             {% for value in item.group_value %}
             {{value}}<br>
             {% endfor %}
         </td>
     </tr>
     {% endif %}
+    {% endif %}
     {% endfor %}
 </table>
+
+<br>
+
+<table class="groups_table" border="1" width="100%" style="font-size: 12;">
+    <th>
+        Name
+    </th>
+    <th>
+        Description
+    </th>
+    <th>
+        Type
+    </th>
+    <th>
+        Value(s)
+    </th>
+    {% for item in group_list|sort(attribute='group_name') %}
+    {% if item.ip_version == 'ipv4' %}
+    {% if item.group_type == 'network-group' %}
+    <tr>
+        <td>
+            {{item.group_name}}
+        </td>
+        <td>
+            {{item.group_desc}}
+        </td>
+        <td align="center">
+            {{item.group_type}}
+        </td>
+        <td align="center">
+            {% for value in item.group_value %}
+            {{value}}<br>
+            {% endfor %}
+        </td>
+    </tr>
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+</table>
+
+
 
 <p class="section_heading">IPv6 Groups</p>
 <table class="groups_table" border="1" width="100%" style="font-size: 12;">
@@ -53,6 +96,7 @@
     </th>
     {% for item in group_list %}
     {% if item.ip_version == 'ipv6' %}
+    {% if item.group_type == 'address-group' %}
     <tr>
         <td>
             {{item.group_name}}
@@ -60,10 +104,87 @@
         <td>
             {{item.group_desc}}
         </td>
-        <td>
+        <td align="center">
             {{item.group_type}}
         </td>
+        <td align="center">
+            {% for value in item.group_value %}
+            {{value}}<br>
+            {% endfor %}
+        </td>
+    </tr>
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+</table>
+
+<br>
+
+<table class="groups_table" border="1" width="100%" style="font-size: 12;">
+    <th>
+        Name
+    </th>
+    <th>
+        Description
+    </th>
+    <th>
+        Type
+    </th>
+    <th>
+        Value(s)
+    </th>
+    {% for item in group_list %}
+    {% if item.ip_version == 'ipv6' %}
+    {% if item.group_type == 'network-group' %}
+    <tr>
         <td>
+            {{item.group_name}}
+        </td>
+        <td>
+            {{item.group_desc}}
+        </td>
+        <td align="center">
+            {{item.group_type}}
+        </td>
+        <td align="center">
+            {% for value in item.group_value %}
+            {{value}}<br>
+            {% endfor %}
+        </td>
+    </tr>
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+</table>
+
+
+<p class="section_heading">Domain Groups</p>
+<table class="groups_table" border="1" width="100%" style="font-size: 12;">
+    <th>
+        Name
+    </th>
+    <th>
+        Description
+    </th>
+    <th>
+        Type
+    </th>
+    <th>
+        Value(s)
+    </th>
+    {% for item in group_list|sort(attribute='group_name') %}
+    {% if item.group_type == 'domain-group' %}
+    <tr>
+        <td>
+            {{item.group_name}}
+        </td>
+        <td>
+            {{item.group_desc}}
+        </td>
+        <td align="center">
+            {{item.group_type}}
+        </td>
+        <td align="center">
             {% for value in item.group_value %}
             {{value}}<br>
             {% endfor %}
@@ -72,4 +193,77 @@
     {% endif %}
     {% endfor %}
 </table>
+
+<p class="section_heading">MAC Groups</p>
+<table class="groups_table" border="1" width="100%" style="font-size: 12;">
+    <th>
+        Name
+    </th>
+    <th>
+        Description
+    </th>
+    <th>
+        Type
+    </th>
+    <th>
+        Value(s)
+    </th>
+    {% for item in group_list|sort(attribute='group_name') %}
+    {% if item.group_type == 'mac-group' %}
+    <tr>
+        <td>
+            {{item.group_name}}
+        </td>
+        <td>
+            {{item.group_desc}}
+        </td>
+        <td align="center">
+            {{item.group_type}}
+        </td>
+        <td align="center">
+            {% for value in item.group_value %}
+            {{value}}<br>
+            {% endfor %}
+        </td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+</table>
+
+<p class="section_heading">Port Groups</p>
+<table class="groups_table" border="1" width="100%" style="font-size: 12;">
+    <th>
+        Name
+    </th>
+    <th>
+        Description
+    </th>
+    <th>
+        Type
+    </th>
+    <th>
+        Value(s)
+    </th>
+    {% for item in group_list|sort(attribute='group_name') %}
+    {% if item.group_type == 'port-group' %}
+    <tr>
+        <td>
+            {{item.group_name}}
+        </td>
+        <td>
+            {{item.group_desc}}
+        </td>
+        <td align="center">
+            {{item.group_type}}
+        </td>
+        <td align="center">
+            {% for value in item.group_value %}
+            {{value}}<br>
+            {% endfor %}
+        </td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+</table>
+<br><br>
 {% endblock body %}

--- a/templates/group_view.html
+++ b/templates/group_view.html
@@ -2,7 +2,7 @@
 {% block body %}
 
 <p class="section_heading">IPv4 Groups</p>
-<table class="groups_table" border="1" width="100%">
+<table class="groups_table" border="1" width="100%" style="font-size: 12;">
     <th>
         Name
     </th>
@@ -38,7 +38,7 @@
 </table>
 
 <p class="section_heading">IPv6 Groups</p>
-<table class="groups_table" border="1" width="100%">
+<table class="groups_table" border="1" width="100%" style="font-size: 12;">
     <th>
         Name
     </th>


### PR DESCRIPTION
v0.12.0
 - Add ability to pass extra configuration statements for configurations not yet implemented in the GUI.
 - Add processing to generate_config for Extra Items.
 - Update filter add and filter rule add to redirect to filter view page.
 - Add option to set default-log option when creating a new chain.
 - Fix filter list function to run for both ip_versions even if one is empty.
 - Fix display issue in filter view template.
 - Fix issue in filter_function that was overwriting filter rules.
 - Fix issue in generate config for chains that did not have default logging when created.
 - Widen interface field to 10 chars to accept bonds with VIFs on filter rule add page.
 - Fix font size on group view page.
 - Update rules to only be IP version specific for address and network groups.
 - Update group adds to only observer IP version for address and network groups. Others all get created at IPv4.
 - Add option to delete all firewall configuration before setting new options.
 - Update commit info displayed after pushing to firewall.
 - Add sorting to JSON file write.
 - Update groups view to separate groups by type.